### PR TITLE
build cryptography=3.4.8 for python 3.10.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,15 +6,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d
+  sha256: 94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c
   patches:
     # Update pyo3 to avoid https://github.com/PyO3/pyo3/pull/1847#discussion_r727122252
     - patches/0001-Use-pyo3-0.15.0-to-fix-cross-compilation.patch  # [build_platform != target_platform]
 
 build:
   number: 1
-  # TEMPORARY: skip everything so that new branch can be pushed
-  skip: true
   skip: true  # [py<36]
   script:
     {% if build_platform != target_platform %}

--- a/recipe/patches/0001-Use-pyo3-0.15.0-to-fix-cross-compilation.patch
+++ b/recipe/patches/0001-Use-pyo3-0.15.0-to-fix-cross-compilation.patch
@@ -11,15 +11,15 @@ diff --git a/src/rust/Cargo.toml b/src/rust/Cargo.toml
 index 6d59072..29c7e29 100644
 --- a/src/rust/Cargo.toml
 +++ b/src/rust/Cargo.toml
-@@ -7,7 +7,7 @@ publish = false
+@@ -6,7 +6,7 @@ edition = "2018"
+ publish = false
  
  [dependencies]
- lazy_static = "1"
--pyo3 = { version = "0.14.5" }
-+pyo3 = { version = "0.15.0" }
- asn1 = { version = "0.6", default-features = false, features = ["derive"] }
- pem = "0.8"
- chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+-pyo3 = { version = "0.13.1", features = ["extension-module"] }
++pyo3 = { version = "0.15.0", features = ["extension-module"] }
+ 
+ [lib]
+ name = "cryptography_rust"
 -- 
-2.30.1 (Apple Git-130)
+2.28.0
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] ~Bumped~ Changed the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Some packages like `snowflake-connector-python` restricting updates of `cryptography` by excluding the next major version i.e. `<4`. In order to progress with the `python=3.10` migration it would be helpful to build latest `cryptography=3.*` also for `python=3.10`. This PR could start some `abi_branch` if there are no objects. Please note: this PR **must not** be merged to master but to some different branch `3.4.x` maybe.