### PR TITLE
debug pypy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,6 @@ outputs:
   - name: cryptography
     build:
       script:
-        # PyPy has weird sysconfigdata name
-        - rm $PREFIX/lib/pypy$PY_VER/_sysconfigdata.py  # [python_impl == "pypy" and build_platform != target_platform and target_platform == "linux-ppc64le"]
         # see below for what OPENSSL_DIR should be pointing to:
         # https://github.com/sfackler/rust-openssl/blob/openssl-sys-v0.9.72/openssl/src/lib.rs#L55-L56
         - export OPENSSL_DIR=$PREFIX        # [unix]


### PR DESCRIPTION
broken since #113

removing the work-around is unrelated but should now be possible (AFAIU) due to upstream pypy fixes.