### PR TITLE
Patch out overly strict cffi lower bound and add pip check

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,6 +18,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ channel_sources:
 - conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
+is_freethreading:
+- false
 openssl:
 - '3'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: fa18b8f91f1c20c162142ed5cb1b90d829bc0159e8c802e78f2583ae5e7ae284
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: cryptography-vectors
@@ -62,7 +62,7 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - cffi >=1.12                            # [build_platform != target_platform]
+        - cffi >=2.0.0                           # [build_platform != target_platform]
         - maturin >=1,<2                         # [build_platform != target_platform]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
@@ -72,12 +72,12 @@ outputs:
         - pip
         - maturin >=1,<2
         - openssl
-        - cffi >=1.12
+        - cffi >=2.0.0
         # used by cffi
         - setuptools
       run:
         - python
-        - cffi >=1.12
+        - cffi >=2.0.0
     test:
       imports:
         - cryptography
@@ -94,6 +94,7 @@ outputs:
         - cryptography.hazmat.primitives.twofactor
         - cryptography.x509
       requires:
+        - pip
         - certifi
         - cryptography-vectors {{ version }}
         - hypothesis
@@ -108,6 +109,7 @@ outputs:
         # for marker definitions
         - pyproject.toml
       commands:
+        - pip check
         # run_test.py will check that the correct openssl version is linked
         - pytest tests
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/pyca/cryptography/archive/refs/tags/{{ version }}.tar.gz
   sha256: fa18b8f91f1c20c162142ed5cb1b90d829bc0159e8c802e78f2583ae5e7ae284
+  patches:
+    - patches/0001-stay-on-old-cffi-for-non-freethreading-builds.patch  # [not is_freethreading]
 
 build:
   number: 2
@@ -62,7 +64,7 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - cffi >=2.0.0                           # [build_platform != target_platform]
+        - cffi >=1.14                            # [build_platform != target_platform]
         - maturin >=1,<2                         # [build_platform != target_platform]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
@@ -72,12 +74,12 @@ outputs:
         - pip
         - maturin >=1,<2
         - openssl
-        - cffi >=2.0.0
+        - cffi >=1.14
         # used by cffi
         - setuptools
       run:
         - python
-        - cffi >=2.0.0
+        - cffi >=1.14
     test:
       imports:
         - cryptography

--- a/recipe/patches/0001-stay-on-old-cffi-for-non-freethreading-builds.patch
+++ b/recipe/patches/0001-stay-on-old-cffi-for-non-freethreading-builds.patch
@@ -1,0 +1,33 @@
+From c4d60eaf7805f54b332963e01cfd53d223e43afb Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 19 Sep 2025 13:23:44 +0200
+Subject: [PATCH] stay on old cffi for non-freethreading builds
+
+---
+ pyproject.toml | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index a0605041f..e99968b63 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,8 +5,7 @@ requires = [
+     "maturin>=1.9.4,<2",
+ 
+     # Must be kept in sync with `project.dependencies`
+-    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
+-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'",
++    "cffi>=1.14",
+     # Used by cffi (which import distutils, and in Python 3.12, distutils has
+     # been removed from the stdlib, but installing setuptools puts it back) as
+     # well as our build.rs for the rust/cffi bridge.
+@@ -51,8 +50,7 @@ classifiers = [
+ requires-python = ">=3.8,!=3.9.0,!=3.9.1"
+ dependencies = [
+     # Must be kept in sync with `build-system.requires`
+-    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
+-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'",
++    "cffi>=1.14",
+     # Must be kept in sync with ./.github/requirements/build-requirements.{in,txt}
+     "typing-extensions>=4.13.2; python_version < '3.11'",
+ ]


### PR DESCRIPTION
In 46.0.1, the lower bound on cffi for the python versions we support was set upstream to >=2.0.0, but as discussed below, this is unnecessarily strict.  To allow `pip check` to pass (here and downstream), we patch to a less strict cffi >=1.14.

https://github.com/pyca/cryptography/blob/46.0.1/pyproject.toml#L9

Added `pip check` to `cryptography` output.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
